### PR TITLE
fix: allow existing users to sign in and link via oauth

### DIFF
--- a/.changeset/fair-lobsters-teach.md
+++ b/.changeset/fair-lobsters-teach.md
@@ -1,0 +1,5 @@
+---
+"payload-auth-plugin": patch
+---
+
+Allow existing users to sign in and link via OAuth by returning the existing user record instead of null in \_createUser.

--- a/src/core/protocols/oauth/oauth_authentication.ts
+++ b/src/core/protocols/oauth/oauth_authentication.ts
@@ -51,9 +51,8 @@ async function _createUser({ email, name, collections, request, allowOAuthAutoSi
       data,
       returning: true
     })
-  } else {
-    return null
-  }
+  } 
+
   return userRecord
 }
 export async function OAuthAuthentication(


### PR DESCRIPTION
### Purpose
    This PR fixes a bug where existing users (e.g. registered via email/password) receive a `UserNotFoundAPIError` when trying to sign in using an OAuth provider (Google, GitHub, etc.) for the first time.

### Problem
   In `_createUser` (inside `src/core/protocols/oauth/oauth_authentication.ts`), if a user already exists, the function hits the
  `else` block and returns `null`. Consequently, the calling function `OAuthAuthentication` treats this as a failed lookup and
  returns `UserNotFoundAPIError` instead of auto-linking the new OAuth provider credentials (`sub`) to the existing user record.

### Solution
  Remove the `else { return null }` block from `_createUser`.
    - If the user record exists, it is now correctly returned to the caller (`OAuthAuthentication`), allowing the provider
  credentials to be linked and the user to log in successfully.
    - If the user does not exist and `allowOAuthAutoSignUp` is `false`, `userRecord` remains `null` and is returned as `null`
  (correctly rejecting sign-up).